### PR TITLE
feat: add run-on input to linode-lke-deploy workflow

### DIFF
--- a/.github/workflows/linode-lke-deploy.yaml
+++ b/.github/workflows/linode-lke-deploy.yaml
@@ -52,6 +52,10 @@ on:
         required: false
         type: string
         default: '3.7.3'
+      run-on:
+        required: false
+        type: string
+        default: "['self-hosted', 'Linux', 'X64', 'macmini']"
 
     outputs:
       image-tag:
@@ -61,7 +65,7 @@ on:
 jobs:
   lke-deploy:
     name: LKE Deploy
-    runs-on: [self-hosted, Linux, X64, macmini]
+    runs-on: ${{ fromJson(inputs.run-on) }}
     outputs:
       image-tag: ${{ inputs.image-tag }}
     environment:


### PR DESCRIPTION
## Summary
- Add `run-on` input parameter to `linode-lke-deploy.yaml` which allows callers to override the runner (e.g. `ubuntu-latest`)
- Default value preserves existing behavior: `['self-hosted', 'Linux', 'X64', 'macmini']`