### PR TITLE
Helm 4 support in aws-eks-deploy reusable workflow

### DIFF
--- a/.github/workflows/aws-eks-deploy.yaml
+++ b/.github/workflows/aws-eks-deploy.yaml
@@ -104,21 +104,15 @@ jobs:
 
       - name: Trust helm-secrets signing key
         if: ${{ inputs.has-secrets }}
-        # Pin the exact provenance key (jkroepke's). curl imports every key the endpoint
-        # serves, but we export ONLY the pinned fingerprint into the keyring Helm verifies
-        # against — so a rogue key added to the endpoint (account compromise) is never
-        # trusted. Update the fingerprint only if the signing key is ever rotated.
         env:
           HELM_SECRETS_SIGNING_FP: "1F34F95B4F30BC5B06E0D7CC3F619F17002790D8"
         run: |
           curl -sSL https://github.com/jkroepke.gpg | gpg --import
-          gpg --list-keys "$HELM_SECRETS_SIGNING_FP"   # fail-fast if the pinned key is absent
+          gpg --list-keys "$HELM_SECRETS_SIGNING_FP"
           gpg --export "$HELM_SECRETS_SIGNING_FP" > "$RUNNER_TEMP/helm-secrets-keyring.gpg"
 
       - name: Install Helm Secrets
         if: ${{ inputs.has-secrets }}
-        # Helm 4: 3 split packages, exact release URLs (no --version). Verify each package's
-        # .prov signature against the pinned keyring built in the previous step.
         run: |
           base="https://github.com/jkroepke/helm-secrets/releases/download/v4.7.7"
           for p in secrets secrets-getter secrets-post-renderer; do
@@ -141,10 +135,6 @@ jobs:
 
       - name: Build Helm Values
         id: build-helm-values
-        # Helm 4: no `helm secrets` wrapper — encrypted values are decrypted by the
-        # secrets:// getter (helm-secrets-getter). Use an ABSOLUTE path so the URI is
-        # secrets:///abs/path (empty host); a relative ./ would parse the leading dot as
-        # the URL host and break resolution.
         env:
           HELM_VALUES_INPUT: ${{ inputs.helm-values }}
           HAS_SECRETS: ${{ inputs.has-secrets }}
@@ -173,8 +163,6 @@ jobs:
         run: echo "deployed-at=$(date +"%Y-%m-%d %T %Z")" >> $GITHUB_OUTPUT
 
       - name: Helm Upgrade
-        # Helm 4: plain `helm upgrade` (the `helm secrets` wrapper was removed);
-        # encrypted values are decrypted by the secrets:// getter set up above.
         run: |
           helm upgrade ${{ inputs.release-name }} ./.deploy --install --rollback-on-failure --wait \
             --namespace ${{ inputs.namespace }} \

--- a/.github/workflows/aws-eks-deploy.yaml
+++ b/.github/workflows/aws-eks-deploy.yaml
@@ -81,9 +81,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      # Helm 4 PoC: per-run data home so `helm plugin install` AND runtime getter lookup
-      # both use the same isolated dir (HELM_PLUGINS only affects runtime, not install),
-      # keeping plugins off the shared Helm-3 cache prod uses on this self-hosted runner.
       - name: Isolate Helm data home
         run: echo "HELM_DATA_HOME=$RUNNER_TEMP/helm4-data-${{ github.run_id }}" >> "$GITHUB_ENV"
 
@@ -165,7 +162,7 @@ jobs:
         # Helm 4: plain `helm upgrade` (the `helm secrets` wrapper was removed);
         # encrypted values are decrypted by the secrets:// getter set up above.
         run: |
-          helm upgrade ${{ inputs.release-name }} ./.deploy --install --atomic --wait \
+          helm upgrade ${{ inputs.release-name }} ./.deploy --install --rollback-on-failure --wait \
             --namespace ${{ inputs.namespace }} \
             ${{ steps.build-helm-values.outputs.helm-values }} \
             --set image.tag=${{ inputs.image-tag }} \

--- a/.github/workflows/aws-eks-deploy.yaml
+++ b/.github/workflows/aws-eks-deploy.yaml
@@ -128,8 +128,9 @@ jobs:
 
       - name: Build Helm Values
         id: build-helm-values
-        # Helm 4: no `helm secrets` wrapper — encrypted values are decrypted via the
-        # `secrets://` getter. Prefix files matching the secrets*.yaml convention.
+        # Helm 4 dropped the `helm secrets` wrapper and the CLI secrets:// getter did not
+        # register. helm-secrets only wraps sops, so decrypt secrets*.yaml directly with
+        # sops (AWS KMS, same keys/role) to a temp file and pass it as a plaintext -f.
         env:
           HELM_VALUES_INPUT: ${{ inputs.helm-values }}
           HAS_SECRETS: ${{ inputs.has-secrets }}
@@ -138,8 +139,12 @@ jobs:
           while IFS= read -r f; do
             [ -z "$f" ] && continue
             case "$HAS_SECRETS:$(basename "$f")" in
-              true:secrets*) helm_values="$helm_values -f secrets://$f" ;;
-              *)             helm_values="$helm_values -f $f" ;;
+              true:secrets*)
+                dec="$RUNNER_TEMP/$(basename "$f").dec.yaml"
+                sops -d "$f" > "$dec"
+                helm_values="$helm_values -f $dec" ;;
+              *)
+                helm_values="$helm_values -f $f" ;;
             esac
           done <<< "$HELM_VALUES_INPUT"
           echo "helm-values=$helm_values" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/aws-eks-deploy.yaml
+++ b/.github/workflows/aws-eks-deploy.yaml
@@ -81,9 +81,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      # Helm 4 PoC: per-run plugin dir, isolated from the shared Helm-3 cache prod uses.
-      - name: Isolate Helm plugins
-        run: echo "HELM_PLUGINS=$RUNNER_TEMP/helm4-plugins-${{ github.run_id }}" >> "$GITHUB_ENV"
+      # Helm 4 PoC: per-run data home so `helm plugin install` AND runtime getter lookup
+      # both use the same isolated dir (HELM_PLUGINS only affects runtime, not install),
+      # keeping plugins off the shared Helm-3 cache prod uses on this self-hosted runner.
+      - name: Isolate Helm data home
+        run: echo "HELM_DATA_HOME=$RUNNER_TEMP/helm4-data-${{ github.run_id }}" >> "$GITHUB_ENV"
 
       - name: Sops Binary Installer
         uses: mdgreenwald/mozilla-sops-action@v1.6.0
@@ -128,9 +130,10 @@ jobs:
 
       - name: Build Helm Values
         id: build-helm-values
-        # Helm 4 dropped the `helm secrets` wrapper and the CLI secrets:// getter did not
-        # register. helm-secrets only wraps sops, so decrypt secrets*.yaml directly with
-        # sops (AWS KMS, same keys/role) to a temp file and pass it as a plaintext -f.
+        # Helm 4: no `helm secrets` wrapper — encrypted values are decrypted by the
+        # secrets:// getter (helm-secrets-getter). Use an ABSOLUTE path so the URI is
+        # secrets:///abs/path (empty host); a relative ./ would parse the leading dot as
+        # the URL host and break resolution.
         env:
           HELM_VALUES_INPUT: ${{ inputs.helm-values }}
           HAS_SECRETS: ${{ inputs.has-secrets }}
@@ -139,12 +142,8 @@ jobs:
           while IFS= read -r f; do
             [ -z "$f" ] && continue
             case "$HAS_SECRETS:$(basename "$f")" in
-              true:secrets*)
-                dec="$RUNNER_TEMP/$(basename "$f").dec.yaml"
-                sops -d "$f" > "$dec"
-                helm_values="$helm_values -f $dec" ;;
-              *)
-                helm_values="$helm_values -f $f" ;;
+              true:secrets*) helm_values="$helm_values -f secrets://$(realpath "$f")" ;;
+              *)             helm_values="$helm_values -f $f" ;;
             esac
           done <<< "$HELM_VALUES_INPUT"
           echo "helm-values=$helm_values" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/aws-eks-deploy.yaml
+++ b/.github/workflows/aws-eks-deploy.yaml
@@ -102,15 +102,29 @@ jobs:
         with:
           version: v4.2.2
 
+      - name: Trust helm-secrets signing key
+        if: ${{ inputs.has-secrets }}
+        # Pin the exact provenance key (jkroepke's). curl imports every key the endpoint
+        # serves, but we export ONLY the pinned fingerprint into the keyring Helm verifies
+        # against — so a rogue key added to the endpoint (account compromise) is never
+        # trusted. Update the fingerprint only if the signing key is ever rotated.
+        env:
+          HELM_SECRETS_SIGNING_FP: "1F34F95B4F30BC5B06E0D7CC3F619F17002790D8"
+        run: |
+          curl -sSL https://github.com/jkroepke.gpg | gpg --import
+          gpg --list-keys "$HELM_SECRETS_SIGNING_FP"   # fail-fast if the pinned key is absent
+          gpg --export "$HELM_SECRETS_SIGNING_FP" > "$RUNNER_TEMP/helm-secrets-keyring.gpg"
+
       - name: Install Helm Secrets
         if: ${{ inputs.has-secrets }}
-        # Helm 4: plugin split into 3 packages, `--version` removed (exact URLs), signing
-        # on by default. `--verify=false` is PoC-only — set up verification before merge.
+        # Helm 4: 3 split packages, exact release URLs (no --version). Verify each package's
+        # .prov signature against the pinned keyring built in the previous step.
         run: |
           base="https://github.com/jkroepke/helm-secrets/releases/download/v4.7.7"
-          helm plugin install "$base/secrets-4.7.7.tgz" --verify=false
-          helm plugin install "$base/secrets-getter-4.7.7.tgz" --verify=false
-          helm plugin install "$base/secrets-post-renderer-4.7.7.tgz" --verify=false
+          for p in secrets secrets-getter secrets-post-renderer; do
+            helm plugin install "$base/$p-4.7.7.tgz" \
+              --verify --keyring "$RUNNER_TEMP/helm-secrets-keyring.gpg"
+          done
 
       - name: AWS Credentials
         uses: aws-actions/configure-aws-credentials@v5.1.1

--- a/.github/workflows/aws-eks-deploy.yaml
+++ b/.github/workflows/aws-eks-deploy.yaml
@@ -81,6 +81,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      # Helm 4 PoC: per-run plugin dir, isolated from the shared Helm-3 cache prod uses.
+      - name: Isolate Helm plugins
+        run: echo "HELM_PLUGINS=$RUNNER_TEMP/helm4-plugins-${{ github.run_id }}" >> "$GITHUB_ENV"
+
       - name: Sops Binary Installer
         uses: mdgreenwald/mozilla-sops-action@v1.6.0
         if: ${{ inputs.has-secrets }}
@@ -97,16 +101,17 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v4.3.1
         with:
-          version: v3.19.4
+          version: v4.2.2
 
       - name: Install Helm Secrets
         if: ${{ inputs.has-secrets }}
+        # Helm 4: plugin split into 3 packages, `--version` removed (exact URLs), signing
+        # on by default. `--verify=false` is PoC-only — set up verification before merge.
         run: |
-          if [[ $(helm plugin list | grep -c "secrets") -eq 0 ]]; then
-              helm plugin install https://github.com/jkroepke/helm-secrets --version v4.6.5
-          else
-              echo "Helm Secrets plugin already installed"
-          fi
+          base="https://github.com/jkroepke/helm-secrets/releases/download/v4.7.7"
+          helm plugin install "$base/secrets-4.7.7.tgz" --verify=false
+          helm plugin install "$base/secrets-getter-4.7.7.tgz" --verify=false
+          helm plugin install "$base/secrets-post-renderer-4.7.7.tgz" --verify=false
 
       - name: AWS Credentials
         uses: aws-actions/configure-aws-credentials@v5.1.1
@@ -141,6 +146,8 @@ jobs:
         run: echo "deployed-at=$(date +"%Y-%m-%d %T %Z")" >> $GITHUB_OUTPUT
 
       - name: Helm Upgrade
+        # Iteration 1: still using the `helm secrets upgrade` wrapper. If Helm 4 rejects
+        # it, switch to `helm upgrade --post-renderer` with the secrets-post-renderer plugin.
         run: |
           helm ${{ inputs.has-secrets && 'secrets' || '' }} upgrade ${{ inputs.release-name }} ./.deploy --install --atomic --wait \
             --namespace ${{ inputs.namespace }} \

--- a/.github/workflows/aws-eks-deploy.yaml
+++ b/.github/workflows/aws-eks-deploy.yaml
@@ -128,9 +128,21 @@ jobs:
 
       - name: Build Helm Values
         id: build-helm-values
+        # Helm 4: no `helm secrets` wrapper — encrypted values are decrypted via the
+        # `secrets://` getter. Prefix files matching the secrets*.yaml convention.
+        env:
+          HELM_VALUES_INPUT: ${{ inputs.helm-values }}
+          HAS_SECRETS: ${{ inputs.has-secrets }}
         run: |
-          helm_values=$(echo '${{ inputs.helm-values }}' | sed '/^$/d' |  sed 's/.*/-f &/' | sed '$!N;s/\n/ /')
-          echo "helm-values=$helm_values" >> $GITHUB_OUTPUT
+          helm_values=""
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$HAS_SECRETS:$(basename "$f")" in
+              true:secrets*) helm_values="$helm_values -f secrets://$f" ;;
+              *)             helm_values="$helm_values -f $f" ;;
+            esac
+          done <<< "$HELM_VALUES_INPUT"
+          echo "helm-values=$helm_values" >> "$GITHUB_OUTPUT"
 
       - name: Build Helm Set Values
         id: build-helm-set-values
@@ -146,10 +158,10 @@ jobs:
         run: echo "deployed-at=$(date +"%Y-%m-%d %T %Z")" >> $GITHUB_OUTPUT
 
       - name: Helm Upgrade
-        # Iteration 1: still using the `helm secrets upgrade` wrapper. If Helm 4 rejects
-        # it, switch to `helm upgrade --post-renderer` with the secrets-post-renderer plugin.
+        # Helm 4: plain `helm upgrade` (the `helm secrets` wrapper was removed);
+        # encrypted values are decrypted by the secrets:// getter set up above.
         run: |
-          helm ${{ inputs.has-secrets && 'secrets' || '' }} upgrade ${{ inputs.release-name }} ./.deploy --install --atomic --wait \
+          helm upgrade ${{ inputs.release-name }} ./.deploy --install --atomic --wait \
             --namespace ${{ inputs.namespace }} \
             ${{ steps.build-helm-values.outputs.helm-values }} \
             --set image.tag=${{ inputs.image-tag }} \


### PR DESCRIPTION
Migrates the shared `aws-eks-deploy.yaml` reusable workflow from Helm 3 to **Helm 4**.

## What changed
- **Helm** `v3.19.4` → `v4.2.2`
- **helm-secrets** `v4.6.5` (single plugin) → `v4.7.7` as **3 split packages** (Helm 4 removed all-in-one plugins & the `--version` flag; exact release URLs)
- **Plugin isolation:** set `HELM_DATA_HOME` per-run (Helm 4 `plugin install` writes there and ignores `HELM_PLUGINS`) — keeps plugins off the shared self-hosted-runner cache
- **Signature verification (B2):** import jkroepke's keys, export ONLY the pinned signing fingerprint `1F34F95B4F30BC5B06E0D7CC3F619F17002790D8` into a keyring, `helm plugin install --verify --keyring` each package (replaces the removed `helm secrets` wrapper's implicit trust)
- **Secrets decryption:** the `helm secrets` wrapper subcommand was removed in Helm 4 → plain `helm upgrade`; encrypted values decrypted via the `secrets://` getter with an **absolute path** (`-f secrets://$(realpath …)`)
- **`--atomic` → `--rollback-on-failure`** (Helm 4 rename; `--wait` already passed explicitly)