### PR TITLE
ci(helm): add a helm lint step

### DIFF
--- a/.github/workflows/helm-unit-tests.yaml
+++ b/.github/workflows/helm-unit-tests.yaml
@@ -17,6 +17,10 @@ on:
         required: false
         type: string
         default: '1.35.0'
+      lint:
+        required: false
+        type: boolean
+        default: true
       release-name:
         required: false
         type: string
@@ -93,6 +97,17 @@ jobs:
             exit 1
           fi
           helm unittest "$CHART_PATH"
+
+      - name: Lint chart
+        if: ${{ inputs.lint }}
+        env:
+          CHART_PATH: ${{ inputs.chart-path }}
+        run: |
+          lint_args=()
+          if [ -f "$CHART_PATH/tests/test-values.yaml" ]; then
+            lint_args=(-f "$CHART_PATH/tests/test-values.yaml")
+          fi
+          helm lint "$CHART_PATH" "${lint_args[@]}"
 
       - name: Install kubeconform
         if: ${{ inputs.validate-manifests }}


### PR DESCRIPTION
Adds a `helm lint` step to `helm-unit-tests.yaml`, between the unit tests and manifest validation.

`helm lint` parses the rendered templates directly, so it catches YAML that `helm template` silently normalises. Concretely, four erp-* charts shipped an `env-secret.yaml` whose `---` separator was glued to the next line by trim markers; rendering and kubeconform were both happy, lint was not:

```
[ERROR] templates/env-secret.yaml: unable to parse YAML: invalid Yaml document separator: apiVersion: v1
```

Details:

- `tests/test-values.yaml` is passed when present, so charts that need secrets can render
- plain `lint`, not `--strict`: warnings should not fail the run yet, since the charts not yet onboarded have not been checked against it
- new `lint` input, boolean, default true